### PR TITLE
added random routing and legacy go buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,3 +3,5 @@ applications:
 - name: simple-go-web-app
   disk: 256M
   memory: 128M
+  buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.7.18
+  random-route: true


### PR DESCRIPTION
I added the random routing in order to avoid the "Server error, status code: 400, error code: 210003, message: The host is taken: simple-go-web-app" error when using a service other people have already used like Pivotal Cloud Foundry (PWS).

I added a previous version of the go buildpack in order to support the version of Go used in this repo (v1.5.x), as I was getting the following error: " **ERROR** Unable to determine Go version to install: no match found for 1.5.x in [1.6.3 1.6.4 1.7.5 1.7.6 1.8.1 1.8.3]"